### PR TITLE
#167891584 Notifications for new travel request(User opt-in or opt-out email notification)

### DIFF
--- a/src/controllers/NotificationOpt.js
+++ b/src/controllers/NotificationOpt.js
@@ -1,0 +1,29 @@
+import jwt from 'jsonwebtoken';
+import db from '../database/models';
+import Response from '../helpers/Response';
+import modifyUserNotificationOpt from '../helpers/modifyUserNotificationOpt';
+
+const { User } = db;
+class NotificationOpt {
+  static async modifyEmailNotificationOption(req, res) {
+    const { emailOpt } = req.body;
+    const { payload } = req.payload;
+    const { email } = payload;
+    const [ rowRetured, updatedUser] = await modifyUserNotificationOpt({ emailOpt }, email);
+    const opt = emailOpt ? 'on' : 'off';
+    
+    const response = new Response(
+      true,
+      200,
+      `email notification turned ${opt}successfully`,
+      {
+        id: updatedUser.id,
+        email: updatedUser.email,
+        emailOpt: updatedUser.emailOpt,
+      });
+
+    return res.status(response.code).send(response);
+  }
+}
+
+export default NotificationOpt;

--- a/src/database/migrations/20190904042655-add-columns-user.js
+++ b/src/database/migrations/20190904042655-add-columns-user.js
@@ -1,0 +1,33 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return Promise.all([
+      queryInterface.addColumn('Users', 'emailOpt', {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+        defaultValue: false
+      }),
+      queryInterface.addColumn('Users', 'inAppOpt', {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+        defaultValue: false
+      })
+    ]);
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return Promise.all([
+      queryInterface.removeColumn('Users', 'emailOpt', {
+        type: Sequelize.BOOLEAN,
+        allowNull: true,
+        defaultValue: false
+      }),
+      queryInterface.removeColumn('Users', 'inAppOpt', {
+        type: Sequelize.BOOLEAN,
+        allowNull: true,
+        defaultValue: false
+      })
+    ]);
+  }
+};

--- a/src/database/models/user.js
+++ b/src/database/models/user.js
@@ -11,7 +11,9 @@ module.exports = (sequelize, DataTypes) => {
       role: DataTypes.ENUM('super admin', 'travel admin', 'travel team member', 'manager', 'requester', 'staff'),
       status: DataTypes.ENUM('active', 'inactive', 'unverified'),
       companyId: DataTypes.UUID,
-      favorites: DataTypes.BOOLEAN
+      favorites: DataTypes.BOOLEAN,
+      emailOpt: DataTypes.BOOLEAN,
+      inAppOpt: DataTypes.BOOLEAN
     },
     {}
   );

--- a/src/helpers/modifyUserNotificationOpt.js
+++ b/src/helpers/modifyUserNotificationOpt.js
@@ -1,0 +1,20 @@
+import db from '../database/models';
+
+const { User } = db;
+/**
+   * @description - this function updates a user email option
+   * @param {object} option
+   * @param {string} email
+   */
+const modifyUserNotificationOpt = async (option, email) => { 
+  const updatedUser = await User.update({ ...option },
+    {
+      where: { email },
+      returning: true,
+      plain: true,
+    }
+  );
+  return updatedUser;
+}
+
+export default modifyUserNotificationOpt;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -7,11 +7,13 @@ import feedbackRoute from './feedback.routes';
 import searchRoute from './search.routes';
 import accomodationRoutes from './accomodation.routes';
 import commentRoute from './comment.routes';
+import notificationOptRoute from './notificationOpt.routes';
 
 const router = Router();
 
 router.use('/auth', authRoute);
 router.use('/trips', tripRoute);
+router.use('/notifications', notificationOptRoute);
 router.use(profileRoute);
 router.use('/user', adminRoute);
 router.use('/accomodation', feedbackRoute);

--- a/src/routes/notificationOpt.routes.js
+++ b/src/routes/notificationOpt.routes.js
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import NotificationOpt from '../controllers/NotificationOpt';
+import validator from '../middlewares/validator';
+import TokenHelper from '../helpers/Token';
+import { emailOptSchema, inAppOptSchema } from '../validation/notificationOptSchema'
+
+const notificationOptRoute = Router();
+
+notificationOptRoute.patch(
+    '/email_opt',
+    TokenHelper.verifyToken,
+    validator(emailOptSchema),
+    NotificationOpt.modifyEmailNotificationOption,
+);
+
+export default notificationOptRoute;

--- a/src/validation/notificationOptSchema.js
+++ b/src/validation/notificationOptSchema.js
@@ -1,0 +1,11 @@
+import { check } from 'express-validator';
+
+const emailOptSchema = [
+  check('emailOpt')
+    .exists()
+    .withMessage('Email option is required')
+    .isBoolean()
+    .withMessage('Email option must be a boolean')
+];
+
+export { emailOptSchema }

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -5,6 +5,7 @@ import app from '../src/index';
 import models from '../src/database/models';
 import jwtHelper from '../src/helpers/Token';
 import users from './mockData/mockAuth';
+import { getMaxListeners } from 'cluster';
 
 const { expect } = chai;
 chai.use(chaiHttp);
@@ -19,14 +20,14 @@ const {
   undefinedDOB, invalidDOB,
   undefinedGender, invalidGender,
   invalidCode, user1, user2,
-  user3, user4, user5, credentials,
+  user3, user4, user5, credentials, credentials2,
   credentialsWithIncorrectCode, credentialsWithIncorrectPassword,
   credentialsWithIncorrectEmail, credentialsWithoutEmail,
   credentialsWithoutCode, credentialsWithInvalidEmail,
   completeLoginWithCode, completeLoginWithoutCode,
-  loginWithWrongCompanyId, credentialsWithInvalidEmail2,
-  credentialsForServerError, credentialsForServerError2,
-  adminAuth, staffAuth, credentials2
+  loginWithWrongCompanyId, credentialsForServerError,
+  credentialsForServerError2, adminAuth,
+  staffAuth, credentialsWithInvalidEmail2
 } = users;
 
 describe('Auth Routes', () => {

--- a/test/mockData/mockBooking.js
+++ b/test/mockData/mockBooking.js
@@ -1,48 +1,50 @@
+import { endOfTomorrow } from 'date-fns';
+
 const accomodationBookings = [
   {
     accomodationId: '3dd3b34a-7554-425e-a688-36afda199619',
     roomId: '3dd3b34a-1254-495e-a688-36afda199619',
-    bookDate: '2019-09-15',
+    bookDate: endOfTomorrow(),
     tripId: 'ff10015c-1624-4490-9b1f-1a2cf0ee4493'
   },
   {
     accomodationId: '3dd3b34a-7554-425e-a688-36afda199619',
     roomId: '3dd3b34a-1254-495e-a688-36afda133619',
-    bookDate: '2019-09-15',
+    bookDate: endOfTomorrow(),
     tripId: 'ff10015c-1624-4490-9b1f-1a2cf0ee4493'
   },
   {
     roomId: '3dd3b34a-1254-495e-a688-36afda133619',
-    bookDate: '2019-09-15',
+    bookDate: endOfTomorrow(),
     tripId: 'ff10015c-1624-4490-9b1f-1a2cf0ee4493'
   },
   {
     accomodationId: '3dd3b34a-7554-425e-a688-36afda199615',
     roomId: '3dd3b34a-1254-495e-a688-36afda133619',
-    bookDate: '2019-09-15',
+    bookDate: endOfTomorrow(),
     tripId: 'ff10015c-1624-4490-9b1f-1a2cf0ee4493'
   },
   {
     accomodationId: '3dd3b34a-7554-425e-a688-36afda199613',
     roomId: '3dd3b34a-1254-495e-a688-36afda133619',
-    bookDate: '2019-09-15',
+    bookDate: endOfTomorrow(),
     tripId: 'ff10015c-1624-4490-9b1f-1a2cf0ee4493'
   },
   {
     accomodationId: '3dd3b34a-7554-425e-a688-36afda199619',
-    bookDate: '2019-09-15',
+    bookDate: endOfTomorrow(),
     tripId: 'ff10015c-1624-4490-9b1f-1a2cf0ee4493'
   },
   {
     accomodationId: '3dd3b34a-7554-425e-a688-36afda199619',
     roomId: '3dd3b34a-1254-495e-a688-36afda133613',
-    bookDate: '2019-09-15',
+    bookDate: endOfTomorrow(),
     tripId: 'ff10015c-1624-4490-9b1f-1a2cf0ee4493'
   },
   {
     accomodationId: '3dd3b34a-7554-425e-a688-36afda199619',
     roomId: '3dd3b34a-1254-495e-a688-36afda199616',
-    bookDate: '2019-09-15',
+    bookDate: endOfTomorrow(),
     tripId: 'ff10015c-1624-4490-9b1f-1a2cf0ee4493'
   },
   {
@@ -54,25 +56,25 @@ const accomodationBookings = [
   {
     accomodationId: '3dd3b34a-7554-425e-a688-36afda199619',
     roomId: '3dd3b34a-1254-495e-a688-36afda133619',
-    bookDate: '2019-09-15',
+    bookDate: endOfTomorrow(),
     tripId: ''
   },
   {
     accomodationId: '3dd3b34a-7554-425e-a688-36afda199619',
     roomId: '3dd3b34a-1254-495e-a688-36afda133619',
-    bookDate: '2019-09-15',
+    bookDate: endOfTomorrow(),
     tripId: 'ff10015c-1624-4490-9b1f-1a2cf0ee4497'
   },
   {
     accomodationId: '3dd3b34a-7554-425e-a688-36afda199619',
     roomId: '3dd3b34a-1254-495e-a688-36afda133619',
-    bookDate: '2019-09-15',
+    bookDate: endOfTomorrow(),
     tripId: 'ffe25dbe-29ea-4759-8462-ed116f6749df'
   },
   {
     accomodationId: '3dd3b34a-7554-425e-a688-36afda199619',
     roomId: '3dd3b34a-1254-495e-a688-36afda133619',
-    bookDate: '2019-09-15',
+    bookDate: endOfTomorrow(),
     tripId: 'ff10015c-1624-4490-9b1f-1a2cf0ee4492'
   },
   {
@@ -84,7 +86,7 @@ const accomodationBookings = [
   {
     accomodationId: '3dd3b34a-7554-425e-a688-36afda199619',
     roomId: '3dd3b34a-1254-495e-a688-36afda199613',
-    bookDate: '2019-09-16',
+    bookDate: endOfTomorrow(),
     tripId: 'ff10015c-1624-4490-9b1f-1a2cf0ee4493'
   }
 ];

--- a/test/notificationOpt.test.js
+++ b/test/notificationOpt.test.js
@@ -1,0 +1,70 @@
+import chai from "chai";
+import chaiHttp from "chai-http";
+import app from "../src/index";
+import users from "./mockData/mockAuth";
+
+const { expect } = chai;
+chai.use(chaiHttp);
+const { staffAuth, adminAuth } = users;
+
+describe("NOTIFICATION OPTION TEST", () => {
+  it("should turn on email notification for admin user", done => {
+    const { token } = adminAuth;
+    chai
+      .request(app)
+      .patch(`/api/v1/notifications/email_opt`)
+      .set({ authorization: `${token}` })
+      .send({ emailOpt: true })
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body).to.be.an("object");
+        expect(res.body.data.email).to.equal("ogedengbe123@gmail.com");
+        expect(res.body.data.emailOpt).to.equal(true);
+        done();
+      });
+  });
+  it("should turn off email notification for admin user", done => {
+    const { token } = adminAuth;
+    chai
+      .request(app)
+      .patch(`/api/v1/notifications/email_opt`)
+      .set({ authorization: `${token}` })
+      .send({ emailOpt: false })
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body).to.be.an("object");
+        expect(res.body.data.email).to.equal("ogedengbe123@gmail.com");
+        expect(res.body.data.emailOpt).to.equal(false);
+        done();
+      });
+  });
+
+  it("should modify turn email notification without emailOpt", done => {
+    const { token } = adminAuth;
+    chai
+      .request(app)
+      .patch(`/api/v1/notifications/email_opt`)
+      .set({ authorization: `${token}` })
+      .send({})
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body.data.emailOpt).to.equal("Email option is required");
+        done();
+      });
+  });
+  it("should modify turn email notification without emailOpt", done => {
+    const { token } = adminAuth;
+    chai
+      .request(app)
+      .patch(`/api/v1/notifications/email_opt`)
+      .set({ authorization: `${token}` })
+      .send({emailOpt: 'trueggfgfsgf'})
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body.data.emailOpt).to.equal(
+          "Email option must be a boolean"
+        );
+        done();
+      });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
Have an admin user opt-in or opt-out of email notification

#### Description of Task to be completed?
- [x] Write unit test
- [x] Modify user table
- [x] Create a helper function that updates the user record
- [x] Create a method that opt-in or opt-out a user email notification

#### How should this be manually tested?
##### Unit test
1. Clone the project repository
2. Cd into the project repository
3. Run `git pull`
4. Run `git checkout  ft-emailNotification-configOpt-endpoint-167891584`
5. Run `npm install`
6. Create database `database_name`
7. Create .env file
8. Run npm test

##### Development test with Postman
 1. Run `npm run devstart`
 2. Launch postman
 3. Create a new patch request with  `/api/v1/notifications/email_opt` 
 4. Add a request body `{ emailOpt: true }`
 5. Add authorization(token) in the request header.
 6. Hit send
#### What are the relevant pivotal tracker stories?
[#167891584](https://www.pivotaltracker.com/story/show/167891584)
#### Any background context you want to add?
Nil
#### Screenshots
Nil
