### PR TITLE
#167891584 Notifications for new travel request(User opt-in or opt-out in-app notification)

### DIFF
--- a/src/controllers/NotificationOpt.js
+++ b/src/controllers/NotificationOpt.js
@@ -4,23 +4,59 @@ import Response from '../helpers/Response';
 import modifyUserNotificationOpt from '../helpers/modifyUserNotificationOpt';
 
 const { User } = db;
+/** */
 class NotificationOpt {
+/**
+ * @param {req} req
+ * @param {res} res
+ * @returns {object} object
+ */
   static async modifyEmailNotificationOption(req, res) {
     const { emailOpt } = req.body;
     const { payload } = req.payload;
     const { email } = payload;
-    const [ rowRetured, updatedUser] = await modifyUserNotificationOpt({ emailOpt }, email);
+    const [, updatedUser] = await modifyUserNotificationOpt({ emailOpt }, email);
     const opt = emailOpt ? 'on' : 'off';
-    
+
     const response = new Response(
       true,
       200,
-      `email notification turned ${opt}successfully`,
+      `email notification turned ${opt} successfully`,
       {
         id: updatedUser.id,
         email: updatedUser.email,
         emailOpt: updatedUser.emailOpt,
-      });
+      }
+    );
+
+    return res.status(response.code).send(response);
+  }
+
+  /**
+  * @param {req} req
+  * @param {res} res
+  * @returns {object} object
+  */
+  static async modifyInAppNotificationOption(req, res) {
+    const { inAppOpt } = req.body;
+    const { payload } = req.payload;
+    const { email } = payload;
+    const [, updatedUser] = await modifyUserNotificationOpt(
+      { inAppOpt },
+      email
+    );
+    const opt = inAppOpt ? 'on' : 'off';
+
+    const response = new Response(
+      true,
+      200,
+      `In-app notification turned ${opt}successfully`,
+      {
+        id: updatedUser.id,
+        email: updatedUser.email,
+        inAppOpt: updatedUser.inAppOpt
+      }
+    );
 
     return res.status(response.code).send(response);
   }

--- a/src/routes/notificationOpt.routes.js
+++ b/src/routes/notificationOpt.routes.js
@@ -2,15 +2,21 @@ import { Router } from 'express';
 import NotificationOpt from '../controllers/NotificationOpt';
 import validator from '../middlewares/validator';
 import TokenHelper from '../helpers/Token';
-import { emailOptSchema, inAppOptSchema } from '../validation/notificationOptSchema'
+import { emailOptSchema, inAppOptSchema } from '../validation/notificationOptSchema';
 
 const notificationOptRoute = Router();
 
 notificationOptRoute.patch(
-    '/email_opt',
-    TokenHelper.verifyToken,
-    validator(emailOptSchema),
-    NotificationOpt.modifyEmailNotificationOption,
+  '/email_opt',
+  TokenHelper.verifyToken,
+  validator(emailOptSchema),
+  NotificationOpt.modifyEmailNotificationOption,
+);
+notificationOptRoute.patch(
+  '/in_app_opt',
+  TokenHelper.verifyToken,
+  validator(inAppOptSchema),
+  NotificationOpt.modifyInAppNotificationOption
 );
 
 export default notificationOptRoute;

--- a/src/validation/notificationOptSchema.js
+++ b/src/validation/notificationOptSchema.js
@@ -8,4 +8,15 @@ const emailOptSchema = [
     .withMessage('Email option must be a boolean')
 ];
 
-export { emailOptSchema }
+const inAppOptSchema = [
+  check('inAppOpt')
+    .exists()
+    .withMessage('In App option is required')
+    .isBoolean()
+    .withMessage('In App option must be a boolean')
+];
+
+export {
+  inAppOptSchema,
+  emailOptSchema
+};

--- a/test/notificationOpt.test.js
+++ b/test/notificationOpt.test.js
@@ -17,13 +17,13 @@ describe("NOTIFICATION OPTION TEST", () => {
       .send({ emailOpt: true })
       .end((err, res) => {
         expect(res).to.have.status(200);
-        expect(res.body).to.be.an("object");
-        expect(res.body.data.email).to.equal("ogedengbe123@gmail.com");
+        expect(res.body).to.be.an('object');
+        expect(res.body.data.email).to.equal('ogedengbe123@gmail.com');
         expect(res.body.data.emailOpt).to.equal(true);
         done();
       });
   });
-  it("should turn off email notification for admin user", done => {
+  it('should turn off email notification for admin user', done => {
     const { token } = adminAuth;
     chai
       .request(app)
@@ -33,13 +33,13 @@ describe("NOTIFICATION OPTION TEST", () => {
       .end((err, res) => {
         expect(res).to.have.status(200);
         expect(res.body).to.be.an("object");
-        expect(res.body.data.email).to.equal("ogedengbe123@gmail.com");
+        expect(res.body.data.email).to.equal('ogedengbe123@gmail.com');
         expect(res.body.data.emailOpt).to.equal(false);
         done();
       });
   });
 
-  it("should modify turn email notification without emailOpt", done => {
+  it('should modify turn email notification without emailOpt', done => {
     const { token } = adminAuth;
     chai
       .request(app)
@@ -52,7 +52,7 @@ describe("NOTIFICATION OPTION TEST", () => {
         done();
       });
   });
-  it("should modify turn email notification without emailOpt", done => {
+  it('should modify turn email notification without emailOpt', done => {
     const { token } = adminAuth;
     chai
       .request(app)
@@ -62,7 +62,66 @@ describe("NOTIFICATION OPTION TEST", () => {
       .end((err, res) => {
         expect(res).to.have.status(400);
         expect(res.body.data.emailOpt).to.equal(
-          "Email option must be a boolean"
+          'Email option must be a boolean'
+        );
+        done();
+      });
+  });
+  it("should turn on in-app notification for admin user", done => {
+    const { token } = adminAuth;
+    chai
+      .request(app)
+      .patch(`/api/v1/notifications/in_app_opt`)
+      .set({ authorization: `${token}` })
+      .send({ inAppOpt: true })
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body).to.be.an("object");
+        expect(res.body.data.email).to.equal("ogedengbe123@gmail.com");
+        expect(res.body.data.inAppOpt).to.equal(true);
+        done();
+      });
+  });
+  it("should turn off in-app notification for admin user", done => {
+    const { token } = adminAuth;
+    chai
+      .request(app)
+      .patch(`/api/v1/notifications/in_app_opt`)
+      .set({ authorization: `${token}` })
+      .send({ inAppOpt: false })
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body).to.be.an("object");
+        expect(res.body.data.email).to.equal("ogedengbe123@gmail.com");
+        expect(res.body.data.inAppOpt).to.equal(false);
+        done();
+      });
+  });
+
+  it("should not modify turn on notification without inAppOpt", done => {
+    const { token } = adminAuth;
+    chai
+      .request(app)
+      .patch(`/api/v1/notifications/in_app_opt`)
+      .set({ authorization: `${token}` })
+      .send({})
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body.data.inAppOpt).to.equal("In App option is required");
+        done();
+      });
+  });
+  it("should not modify turn email notification with invalid inAppOpt", done => {
+    const { token } = adminAuth;
+    chai
+      .request(app)
+      .patch(`/api/v1/notifications/in_app_opt`)
+      .set({ authorization: `${token}` })
+      .send({ inAppOpt: 'trueggfgfsgf' })
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body.data.inAppOpt).to.equal(
+          "In App option must be a boolean"
         );
         done();
       });


### PR DESCRIPTION
#### What does this PR do?
Have an admin user opt-in or opt-out of in-app notification

#### Description of Task to be completed?
- [x] Write unit test
- [x] Write documentation
- [x] Reuse the helper function that updates the user record
- [x] Create a method that opt-in or opt-out a user in-app notification

#### How should this be manually tested?
##### Unit test
1. Clone the project repository
2. Cd into the project repository
3. Run `git pull`
4. Run `git checkout  ft-inAppNotification-configOpt-endpoint-167891584`
5. Run `npm install`
6. Create database `database_name`
7. Create .env file
8. Run npm test

##### Development test with Postman
 1. Run `npm run devstart`
 2. Launch postman
 3. Create a new patch request with  `/api/v1/notifications/in_app_opt` 
 4. Add a request body `{ inAppOpt: true }`
 5. Add authorization(token) in the request header.
 6. Hit send

#### What are the relevant pivotal tracker stories?
[#167891584](https://www.pivotaltracker.com/story/show/167891584)
#### Any background context you want to add?
Nil
#### Screenshots
Nil
