### PR TITLE
#167891608: Users most travelled destinations info

### DIFF
--- a/src/database/migrations/20190908204037-add-values-trip-status-field.js
+++ b/src/database/migrations/20190908204037-add-values-trip-status-field.js
@@ -1,0 +1,21 @@
+import replaceEnum from 'sequelize-replace-enum-postgres';
+
+module.exports = {
+  up: queryInterface => replaceEnum({
+    queryInterface,
+    tableName: 'Trips',
+    columnName: 'status',
+    defaultValue: 'pending',
+    newValues: ['started', 'completed', 'pending', 'rejected', 'approved'],
+    enumName: 'enum_Trips_status'
+  }),
+
+  down: queryInterface => replaceEnum({
+    queryInterface,
+    tableName: 'Trips',
+    columnName: 'status',
+    defaultValue: 'pending',
+    newValues: ['started', 'completed', 'pending', 'rejected', 'approved'],
+    enumName: 'enum_Trips_status'
+  })
+};

--- a/src/routes/trip.routes.js
+++ b/src/routes/trip.routes.js
@@ -44,4 +44,6 @@ tripRoutes.patch(
   TripController.modifyTripRequestStatus,
 );
 
+tripRoutes.get('/mostvisited', Token.verifyToken, TripController.getMostVisitedBranch);
+
 export default tripRoutes;

--- a/test/trip.test.js
+++ b/test/trip.test.js
@@ -10,7 +10,7 @@ import mockTripRequests from './mockData/mockTrips';
 
 chai.use(chaiHttp);
 const { expect } = chai;
-const { Trip } = models;
+const { Trip, Stop } = models;
 const tripId = 'ffe25dbe-29ea-4759-8461-ed116f6739df';
 const invalidtripId = 'ffe25dbe-29ea-4759-8461-ed116f6740df';
 const {
@@ -68,179 +68,179 @@ describe('Travel Request', () => {
       });
     });
   });
-});
 
-describe('Create travel request test', () => {
-  before((done) => {
-    chai.request(app)
-      .post('/api/v1/auth/login')
-      .send(credentials)
-      .end((err, res) => {
-        const { token } = res.body.data.user;
-        validUserToken = token;
-        done();
+  describe('Create travel request test', () => {
+    before((done) => {
+      chai.request(app)
+        .post('/api/v1/auth/login')
+        .send(credentials)
+        .end((err, res) => {
+          const { token } = res.body.data.user;
+          validUserToken = token;
+          done();
+        });
+    });
+
+    describe('Create one way travel request', () => {
+      it('should create a one-way travel request', (done) => {
+        chai.request(app)
+          .post(baseURL)
+          .send(oneWay[0])
+          .set('authorization', validUserToken)
+          .end((err, res) => {
+            const { trip } = res.body.data;
+            expect(res.status).to.equal(201);
+            expect(res.body.data).to.haveOwnProperty('trip');
+            expect(trip.type).to.eql(oneWay[0].type);
+            expect(trip.startBranchId).to.eql(oneWay[0].from);
+            expect(trip.reason).to.eql(oneWay[0].reason);
+            expect(new Date(trip.tripDate)).to.eql(new Date(oneWay[0].departureDate));
+            expect(trip.stop[0].destinationBranchId).to.eql(oneWay[0].destinations[0].to);
+            expect(trip.stop[0].accomodationId).to.eql(oneWay[0].destinations[0].accomodation);
+            done();
+          });
       });
-  });
-
-  describe('Create one way travel request', () => {
-    it('should create a one-way travel request', (done) => {
-      chai.request(app)
-        .post(baseURL)
-        .send(oneWay[0])
-        .set('authorization', validUserToken)
-        .end((err, res) => {
-          const { trip } = res.body.data;
-          expect(res.status).to.equal(201);
-          expect(res.body.data).to.haveOwnProperty('trip');
-          expect(trip.type).to.eql(oneWay[0].type);
-          expect(trip.startBranchId).to.eql(oneWay[0].from);
-          expect(trip.reason).to.eql(oneWay[0].reason);
-          expect(new Date(trip.tripDate)).to.eql(new Date(oneWay[0].departureDate));
-          expect(trip.stop[0].destinationBranchId).to.eql(oneWay[0].destinations[0].to);
-          expect(trip.stop[0].accomodationId).to.eql(oneWay[0].destinations[0].accomodation);
-          done();
-        });
-    });
-    it('should return an error when trip type is invalid', (done) => {
-      chai.request(app)
-        .post(baseURL)
-        .send(oneWay[1])
-        .set('authorization', validUserToken)
-        .end((err, res) => {
-          expect(res.status).to.eql(400);
-          expect(res.body.message).to.eql('Validation Error!');
-          expect(res.body.data.type).to.eql('Invalid trip type');
-          done();
-        });
-    });
-    it('should return an error when passed invalid start branch', (done) => {
-      chai.request(app)
-        .post(baseURL)
-        .send(oneWay[2])
-        .set('authorization', validUserToken)
-        .end((err, res) => {
-          expect(res.status).to.eql(400);
-          expect(res.body.message).to.eql('Validation Error!');
-          expect(res.body.data.from).to.eql(
-            'Start branch location does not exist'
-          );
-          done();
-        });
-    });
-    it('should return an error when passed invalid destination branch', (done) => {
-      chai.request(app)
-        .post(baseURL)
-        .send(oneWay[3])
-        .set('authorization', validUserToken)
-        .end((err, res) => {
-          expect(res.status).to.eql(400);
-          expect(res.body.message).to.eql('Validation Error!');
-          expect(res.body.data['destinations[0].to']).to.eql(
-            'Destination does not exist'
-          );
-          done();
-        });
-    });
-    it('should return an error when start branch is equal to destination', (done) => {
-      chai.request(app)
-        .post(baseURL)
-        .send(oneWay[4])
-        .set('authorization', validUserToken)
-        .end((err, res) => {
-          expect(res.status).to.eql(400);
-          expect(res.body.message).to.eql('Validation Error!');
-          expect(res.body.data['destinations[0].to']).to.eql(
-            'Start and Destination should not be the same'
-          );
-          done();
-        });
-    });
-    it('should return an error when accomodation does not exist', (done) => {
-      chai.request(app)
-        .post(baseURL)
-        .send(oneWay[5])
-        .set('authorization', validUserToken)
-        .end((err, res) => {
-          expect(res.status).to.eql(400);
-          expect(res.body.message).to.eql('Validation Error!');
-          expect(res.body.data['destinations[0].accomodation']).to.eql(
-            'Accomodation does not exist'
-          );
-          done();
-        });
-    });
-    it('should return an error when trip type is empty', (done) => {
-      chai.request(app)
-        .post(baseURL)
-        .send(oneWay[6])
-        .set('authorization', validUserToken)
-        .end((err, res) => {
-          expect(res.status).to.eql(400);
-          expect(res.body.message).to.eql('Validation Error!');
-          expect(res.body.data.type).to.eql('Trip type is required');
-          done();
-        });
-    });
-    it('should return an error when start branch is empty', (done) => {
-      chai.request(app)
-        .post(baseURL)
-        .send(oneWay[7])
-        .set('authorization', validUserToken)
-        .end((err, res) => {
-          expect(res.status).to.eql(400);
-          expect(res.body.message).to.eql('Validation Error!');
-          expect(res.body.data.from).to.eql('Starting point is required');
-          done();
-        });
-    });
-    it('should return an error when departure date is empty', (done) => {
-      chai.request(app)
-        .post(baseURL)
-        .send(oneWay[8])
-        .set('authorization', validUserToken)
-        .end((err, res) => {
-          expect(res.status).to.eql(400);
-          expect(res.body.message).to.eql('Validation Error!');
-          expect(res.body.data.departureDate).to.eql('Departure date is required');
-          done();
-        });
-    });
-    it('should return an error when departure date is invalid', (done) => {
-      chai.request(app)
-        .post(baseURL)
-        .send(oneWay[9])
-        .set('authorization', validUserToken)
-        .end((err, res) => {
-          expect(res.status).to.eql(400);
-          expect(res.body.message).to.eql('Validation Error!');
-          expect(res.body.data.departureDate).to.eql('Invalid departure date format');
-          done();
-        });
-    });
-    it('should return an error when travel reason is empty', (done) => {
-      chai.request(app)
-        .post(baseURL)
-        .send(oneWay[10])
-        .set('authorization', validUserToken)
-        .end((err, res) => {
-          expect(res.status).to.eql(400);
-          expect(res.body.message).to.eql('Validation Error!');
-          expect(res.body.data.reason).to.eql('Travel reason is required');
-          done();
-        });
-    });
-    it('should return a 500 error when an error occurs on the server', (done) => {
-      const stub = sinon.stub(Trip, 'create')
-        .rejects(new Error('Server error, Please try again later'));
-      chai.request(app)
-        .post(baseURL)
-        .send(oneWay[0])
-        .set('authorization', validUserToken)
-        .end((err, res) => {
-          expect(res.status).to.equal(500);
-          stub.restore();
-          done();
-        });
+      it('should return an error when trip type is invalid', (done) => {
+        chai.request(app)
+          .post(baseURL)
+          .send(oneWay[1])
+          .set('authorization', validUserToken)
+          .end((err, res) => {
+            expect(res.status).to.eql(400);
+            expect(res.body.message).to.eql('Validation Error!');
+            expect(res.body.data.type).to.eql('Invalid trip type');
+            done();
+          });
+      });
+      it('should return an error when passed invalid start branch', (done) => {
+        chai.request(app)
+          .post(baseURL)
+          .send(oneWay[2])
+          .set('authorization', validUserToken)
+          .end((err, res) => {
+            expect(res.status).to.eql(400);
+            expect(res.body.message).to.eql('Validation Error!');
+            expect(res.body.data.from).to.eql(
+              'Start branch location does not exist'
+            );
+            done();
+          });
+      });
+      it('should return an error when passed invalid destination branch', (done) => {
+        chai.request(app)
+          .post(baseURL)
+          .send(oneWay[3])
+          .set('authorization', validUserToken)
+          .end((err, res) => {
+            expect(res.status).to.eql(400);
+            expect(res.body.message).to.eql('Validation Error!');
+            expect(res.body.data['destinations[0].to']).to.eql(
+              'Destination does not exist'
+            );
+            done();
+          });
+      });
+      it('should return an error when start branch is equal to destination', (done) => {
+        chai.request(app)
+          .post(baseURL)
+          .send(oneWay[4])
+          .set('authorization', validUserToken)
+          .end((err, res) => {
+            expect(res.status).to.eql(400);
+            expect(res.body.message).to.eql('Validation Error!');
+            expect(res.body.data['destinations[0].to']).to.eql(
+              'Start and Destination should not be the same'
+            );
+            done();
+          });
+      });
+      it('should return an error when accomodation does not exist', (done) => {
+        chai.request(app)
+          .post(baseURL)
+          .send(oneWay[5])
+          .set('authorization', validUserToken)
+          .end((err, res) => {
+            expect(res.status).to.eql(400);
+            expect(res.body.message).to.eql('Validation Error!');
+            expect(res.body.data['destinations[0].accomodation']).to.eql(
+              'Accomodation does not exist'
+            );
+            done();
+          });
+      });
+      it('should return an error when trip type is empty', (done) => {
+        chai.request(app)
+          .post(baseURL)
+          .send(oneWay[6])
+          .set('authorization', validUserToken)
+          .end((err, res) => {
+            expect(res.status).to.eql(400);
+            expect(res.body.message).to.eql('Validation Error!');
+            expect(res.body.data.type).to.eql('Trip type is required');
+            done();
+          });
+      });
+      it('should return an error when start branch is empty', (done) => {
+        chai.request(app)
+          .post(baseURL)
+          .send(oneWay[7])
+          .set('authorization', validUserToken)
+          .end((err, res) => {
+            expect(res.status).to.eql(400);
+            expect(res.body.message).to.eql('Validation Error!');
+            expect(res.body.data.from).to.eql('Starting point is required');
+            done();
+          });
+      });
+      it('should return an error when departure date is empty', (done) => {
+        chai.request(app)
+          .post(baseURL)
+          .send(oneWay[8])
+          .set('authorization', validUserToken)
+          .end((err, res) => {
+            expect(res.status).to.eql(400);
+            expect(res.body.message).to.eql('Validation Error!');
+            expect(res.body.data.departureDate).to.eql('Departure date is required');
+            done();
+          });
+      });
+      it('should return an error when departure date is invalid', (done) => {
+        chai.request(app)
+          .post(baseURL)
+          .send(oneWay[9])
+          .set('authorization', validUserToken)
+          .end((err, res) => {
+            expect(res.status).to.eql(400);
+            expect(res.body.message).to.eql('Validation Error!');
+            expect(res.body.data.departureDate).to.eql('Invalid departure date format');
+            done();
+          });
+      });
+      it('should return an error when travel reason is empty', (done) => {
+        chai.request(app)
+          .post(baseURL)
+          .send(oneWay[10])
+          .set('authorization', validUserToken)
+          .end((err, res) => {
+            expect(res.status).to.eql(400);
+            expect(res.body.message).to.eql('Validation Error!');
+            expect(res.body.data.reason).to.eql('Travel reason is required');
+            done();
+          });
+      });
+      it('should return a 500 error when an error occurs on the server', (done) => {
+        const stub = sinon.stub(Trip, 'create')
+          .rejects(new Error('Server error, Please try again later'));
+        chai.request(app)
+          .post(baseURL)
+          .send(oneWay[0])
+          .set('authorization', validUserToken)
+          .end((err, res) => {
+            expect(res.status).to.equal(500);
+            stub.restore();
+            done();
+          });
+      });
     });
   });
 
@@ -401,223 +401,223 @@ describe('Create travel request test', () => {
         });
     });
   });
-});
 
-describe('Create multi-city trip request', () => {
-  before('Login an unverified user', (done) => {
-    chai
-      .request(app)
-      .post('/api/v1/auth/login')
-      .send(unverifiedLogin)
-      .end((err, res) => {
-        const { token } = res.body.data.user;
-        unverifiedUserToken = token;
-        done(err);
-      });
-  });
-
-  it('should create a multi-city trip request', (done) => {
-    chai
-      .request(app)
-      .post(baseURL)
-      .send(multiple[0])
-      .set('authorization', validUserToken)
-      .end((err, res) => {
-        const { trip, trip: { stop } } = res.body.data;
-        expect(res.status).to.equal(201);
-        expect(trip.type).to.eql(multiple[0].type);
-        expect(trip.startBranchId).to.eql(multiple[0].from);
-        expect(trip.reason).to.eql(multiple[0].reason);
-        expect(stop).to.be.an('array');
-        expect(stop.length).to.be.greaterThan(1);
-        done(err);
-      });
-  });
-
-  it('should return an error if an unverified user makes a request', (done) => {
-    chai
-      .request(app)
-      .post(baseURL)
-      .send(multiple[0])
-      .set('authorization', unverifiedUserToken)
-      .end((err, res) => {
-        const { success, code, message } = res.body;
-        expect(res).to.have.status(403);
-        expect(success).to.equal(false);
-        expect(code).to.equal(403);
-        expect(message).to.eql('Your account has not been verified');
-        done(err);
-      });
-  });
-
-  it('should return an error if one or more destinations are the same', (done) => {
-    chai
-      .request(app)
-      .post(baseURL)
-      .send(multiple[1])
-      .set('authorization', validUserToken)
-      .end((err, res) => {
-        expect(res).to.have.status(400);
-        expect(res.body.success).to.equal(false);
-        expect(res.body.message)
-          .to.eql('Validation Error!');
-        done(err);
-      });
-  });
-});
-
-describe('Avail Requests for approval', () => {
-  before('Login to get manager\'s token', (done) => {
-    chai
-      .request(app)
-      .post('/api/v1/auth/login')
-      .send(manager)
-      .end((err, res) => {
-        const { token } = res.body.data.user;
-        validManagerToken = token;
-        done(err);
-      });
-  });
-
-  before('Login to non-manager\'s token', (done) => {
-    chai
-      .request(app)
-      .post('/api/v1/auth/login')
-      .send(nonManager)
-      .end((err, res) => {
-        const { token } = res.body.data.user;
-        nonManagerToken = token;
-        done(err);
-      });
-  });
-
-  before('Login to manager without pending request', (done) => {
-    chai
-      .request(app)
-      .post('/api/v1/auth/login')
-      .send(nonManage)
-      .end((err, res) => {
-        const { token } = res.body.data.user;
-        nonPending = token;
-        done(err);
-      });
-  });
-
-  describe('Get all request', () => {
-    it('should get all trip requests', (done) => {
+  describe('Create multi-city trip request', () => {
+    before('Login an unverified user', (done) => {
       chai
         .request(app)
-        .get(baseURL)
-        .set('authorization', validManagerToken)
+        .post('/api/v1/auth/login')
+        .send(unverifiedLogin)
         .end((err, res) => {
-          expect(res).to.have.status(200);
-          expect(res.body.success).to.equal(true);
-          expect(res.body.message)
-            .to.eql('Requests retrieved');
-          expect(res.body.data).to.be.an('array');
+          const { token } = res.body.data.user;
+          unverifiedUserToken = token;
           done(err);
         });
     });
 
-    it('should get all pending trip requests', (done) => {
+    it('should create a multi-city trip request', (done) => {
       chai
         .request(app)
-        .get(`${baseURL}?type=pending`)
-        .set('authorization', validManagerToken)
+        .post(baseURL)
+        .send(multiple[0])
+        .set('authorization', validUserToken)
         .end((err, res) => {
-          expect(res).to.have.status(200);
-          expect(res.body.success).to.equal(true);
-          expect(res.body.message)
-            .to.eql('Requests retrieved');
-          expect(res.body.data).to.be.an('array');
+          const { trip, trip: { stop } } = res.body.data;
+          expect(res.status).to.equal(201);
+          expect(trip.type).to.eql(multiple[0].type);
+          expect(trip.startBranchId).to.eql(multiple[0].from);
+          expect(trip.reason).to.eql(multiple[0].reason);
+          expect(stop).to.be.an('array');
+          expect(stop.length).to.be.greaterThan(1);
           done(err);
         });
     });
 
-    it('should get all approved trip requests', (done) => {
+    it('should return an error if an unverified user makes a request', (done) => {
       chai
         .request(app)
-        .get(`${baseURL}?type=approved`)
-        .set('authorization', validManagerToken)
+        .post(baseURL)
+        .send(multiple[0])
+        .set('authorization', unverifiedUserToken)
         .end((err, res) => {
-          expect(res).to.have.status(200);
-          expect(res.body.success).to.equal(true);
-          expect(res.body.message)
-            .to.eql('Requests retrieved');
-          expect(res.body.data).to.be.an('array');
-          done(err);
-        });
-    });
-
-    it('should get all rejected trip requests', (done) => {
-      chai
-        .request(app)
-        .get(`${baseURL}?type=rejected`)
-        .set('authorization', validManagerToken)
-        .end((err, res) => {
-          expect(res).to.have.status(200);
-          expect(res.body.success).to.equal(true);
-          expect(res.body.message)
-            .to.eql('Requests retrieved');
-          expect(res.body.data).to.be.an('array');
-          done(err);
-        });
-    });
-
-    it('should return an error if there are no pending requests', (done) => {
-      chai
-        .request(app)
-        .get(baseURL)
-        .set('authorization', nonPending)
-        .end((err, res) => {
-          const { success, message } = res.body;
-          expect(res.status).to.equal(404);
-          expect(success).to.equal(false);
-          expect(message).to.eql('No pending requests');
-          done(err);
-        });
-    });
-
-    it('should return an error if token is not supplied', (done) => {
-      chai
-        .request(app)
-        .get(baseURL)
-        .set('authorization', '')
-        .end((err, res) => {
-          expect(res).to.have.status(401);
-          expect(res.body.success).to.equal(false);
-          expect(res.body.message)
-            .to.eql('Unathorized, You did not provide a token');
-          done(err);
-        });
-    });
-
-    it('should return an error if an unauthorized tries to make request', (done) => {
-      chai
-        .request(app)
-        .get(baseURL)
-        .set('authorization', nonManagerToken)
-        .end((err, res) => {
+          const { success, code, message } = res.body;
           expect(res).to.have.status(403);
-          expect(res.body.success).to.equal(false);
-          expect(res.body.message)
-            .to.eql('access denied');
+          expect(success).to.equal(false);
+          expect(code).to.equal(403);
+          expect(message).to.eql('Your account has not been verified');
           done(err);
         });
     });
 
-    it('should return a 500 error when an error occurs on the server', (done) => {
-      const stub = sinon.stub(Trip, 'findAll')
-        .rejects(new Error('Server error, Please try again later'));
+    it('should return an error if one or more destinations are the same', (done) => {
       chai
         .request(app)
-        .get(baseURL)
-        .set('authorization', validManagerToken)
+        .post(baseURL)
+        .send(multiple[1])
+        .set('authorization', validUserToken)
         .end((err, res) => {
-          expect(res.status).to.equal(500);
-          stub.restore();
+          expect(res).to.have.status(400);
+          expect(res.body.success).to.equal(false);
+          expect(res.body.message)
+            .to.eql('Validation Error!');
           done(err);
         });
+    });
+  });
+
+  describe('Avail Requests for approval', () => {
+    before('Login to get manager\'s token', (done) => {
+      chai
+        .request(app)
+        .post('/api/v1/auth/login')
+        .send(manager)
+        .end((err, res) => {
+          const { token } = res.body.data.user;
+          validManagerToken = token;
+          done(err);
+        });
+    });
+
+    before('Login to non-manager\'s token', (done) => {
+      chai
+        .request(app)
+        .post('/api/v1/auth/login')
+        .send(nonManager)
+        .end((err, res) => {
+          const { token } = res.body.data.user;
+          nonManagerToken = token;
+          done(err);
+        });
+    });
+
+    before('Login to manager without pending request', (done) => {
+      chai
+        .request(app)
+        .post('/api/v1/auth/login')
+        .send(nonManage)
+        .end((err, res) => {
+          const { token } = res.body.data.user;
+          nonPending = token;
+          done(err);
+        });
+    });
+
+    describe('Get all request', () => {
+      it('should get all trip requests', (done) => {
+        chai
+          .request(app)
+          .get(baseURL)
+          .set('authorization', validManagerToken)
+          .end((err, res) => {
+            expect(res).to.have.status(200);
+            expect(res.body.success).to.equal(true);
+            expect(res.body.message)
+              .to.eql('Requests retrieved');
+            expect(res.body.data).to.be.an('array');
+            done(err);
+          });
+      });
+
+      it('should get all pending trip requests', (done) => {
+        chai
+          .request(app)
+          .get(`${baseURL}?type=pending`)
+          .set('authorization', validManagerToken)
+          .end((err, res) => {
+            expect(res).to.have.status(200);
+            expect(res.body.success).to.equal(true);
+            expect(res.body.message)
+              .to.eql('Requests retrieved');
+            expect(res.body.data).to.be.an('array');
+            done(err);
+          });
+      });
+
+      it('should get all approved trip requests', (done) => {
+        chai
+          .request(app)
+          .get(`${baseURL}?type=approved`)
+          .set('authorization', validManagerToken)
+          .end((err, res) => {
+            expect(res).to.have.status(200);
+            expect(res.body.success).to.equal(true);
+            expect(res.body.message)
+              .to.eql('Requests retrieved');
+            expect(res.body.data).to.be.an('array');
+            done(err);
+          });
+      });
+
+      it('should get all rejected trip requests', (done) => {
+        chai
+          .request(app)
+          .get(`${baseURL}?type=rejected`)
+          .set('authorization', validManagerToken)
+          .end((err, res) => {
+            expect(res).to.have.status(200);
+            expect(res.body.success).to.equal(true);
+            expect(res.body.message)
+              .to.eql('Requests retrieved');
+            expect(res.body.data).to.be.an('array');
+            done(err);
+          });
+      });
+
+      it('should return an error if there are no pending requests', (done) => {
+        chai
+          .request(app)
+          .get(baseURL)
+          .set('authorization', nonPending)
+          .end((err, res) => {
+            const { success, message } = res.body;
+            expect(res.status).to.equal(404);
+            expect(success).to.equal(false);
+            expect(message).to.eql('No pending requests');
+            done(err);
+          });
+      });
+
+      it('should return an error if token is not supplied', (done) => {
+        chai
+          .request(app)
+          .get(baseURL)
+          .set('authorization', '')
+          .end((err, res) => {
+            expect(res).to.have.status(401);
+            expect(res.body.success).to.equal(false);
+            expect(res.body.message)
+              .to.eql('Unathorized, You did not provide a token');
+            done(err);
+          });
+      });
+
+      it('should return an error if an unauthorized tries to make request', (done) => {
+        chai
+          .request(app)
+          .get(baseURL)
+          .set('authorization', nonManagerToken)
+          .end((err, res) => {
+            expect(res).to.have.status(403);
+            expect(res.body.success).to.equal(false);
+            expect(res.body.message)
+              .to.eql('access denied');
+            done(err);
+          });
+      });
+
+      it('should return a 500 error when an error occurs on the server', (done) => {
+        const stub = sinon.stub(Trip, 'findAll')
+          .rejects(new Error('Server error, Please try again later'));
+        chai
+          .request(app)
+          .get(baseURL)
+          .set('authorization', validManagerToken)
+          .end((err, res) => {
+            expect(res.status).to.equal(500);
+            stub.restore();
+            done(err);
+          });
+      });
     });
   });
 
@@ -679,6 +679,30 @@ describe('Avail Requests for approval', () => {
           expect(res.body.message)
             .to.eql('access denied');
           done(err);
+        });
+    });
+  });
+  describe('Get company most visited branch', () => {
+    it('should return the logged in user company most travelled destination', (done) => {
+      chai.request(app).get(`${baseURL}/mostvisited`)
+        .set('authorization', validUserToken)
+        .end((err, res) => {
+          expect(res.status).to.eq(200);
+          expect(res.body.message).to.eq('Successfully retrieved company user\'s most travelled destinations');
+          expect(res.body.data).to.be.an('Array');
+          done();
+        });
+    });
+    it('should return error 500 if there is a server error', (done) => {
+      const stub = sinon.stub(Stop, 'count')
+        .rejects(new Error('Server error, please try again'));
+      chai.request(app).get(`${baseURL}/mostvisited`)
+        .set('authorization', validUserToken)
+        .end((err, res) => {
+          expect(res.status).to.eq(500);
+          expect(res.body.message).to.eq('Server error, please try again');
+          stub.restore();
+          done();
         });
     });
   });


### PR DESCRIPTION
#### What does this PR do?

- Add an endpoint for getting a company's most travelled destinations

#### Description of Task to be completed?

- Check that a user is logged in and active
- Get the user's company and select most travelled destinations of the company staff
- return the response 

#### How should this be manually tested?

- on Postman, log in a user and send a get request to `/api/v1/trips/mostvisited` passing the auth token in the header

#### Any background context you want to provide?

- none

#### What are the relevant pivotal tracker stories?

- [Starts #167891608](https://www.pivotaltracker.com/story/show/167891608)

#### Screenshots (if appropriate)
#### Questions:
