### PR TITLE
#167891607 Users should get stats of trips made in the last X timeframe

### DIFF
--- a/src/controllers/Trip.js
+++ b/src/controllers/Trip.js
@@ -1,7 +1,9 @@
-import { Op } from 'sequelize';
+import Sequelize from 'sequelize';
 import db from '../database/models';
 import Response from '../helpers/Response';
+import date from '../utils/date';
 
+const { Op } = Sequelize;
 const {
   Trip, Branch, User, Stop, Accomodation, Location
 } = db;
@@ -423,6 +425,30 @@ class TripController {
         new Response(false, 500, error.message)
       );
     }
+  }
+  static async countTripsByTimeframe(req, res) {
+    const { start, end } = req.query;
+    const { payload } = req.payload;
+    const formatStartDate = date.format(start);
+    const formatEnDate = date.format(end);
+    const tripCount = await Trip.count({
+      where: {
+        userId: payload.id,
+        createdAt: {
+          [Op.between]: [start, end]
+        }
+      }
+    });
+    const message = formatStartDate !== formatEnDate ?
+      `Number of trip requests between ${formatStartDate} and ${formatEnDate}` :
+      `Number trip requests for ${formatEnDate}`;
+    const response = new Response(
+      true,
+      200,
+      message,
+      { tripCount }
+    );
+    return res.status(response.code).json(response);
   }
 }
 

--- a/src/database/seeders/20190821112340-companies.js
+++ b/src/database/seeders/20190821112340-companies.js
@@ -21,6 +21,13 @@ module.exports = {
       address: '12 Ikorodu Road, Lagos',
       code: 'BAREFOOT',
       owner: 'Barefoot Admin'
+    },
+    {
+      id: 'e819fb11-d55f-4cbf-ad04-894d53cee722',
+      name: 'Soft Blues Limited',
+      address: '234 Muriokunola street, Lagos Island',
+      code: 'SB0002',
+      owner: 'Brightside'
     }
   ]),
   down: queryInterface => queryInterface.bulkDelete('Companies', null, {})

--- a/src/database/seeders/20190821112700-users.js
+++ b/src/database/seeders/20190821112700-users.js
@@ -132,6 +132,42 @@ module.exports = {
       gender: 'male',
       dob: '2012-09-10',
       status: 'active',
+      role: 'manager'
+    },
+    {
+      id: '8c2b1bb8-c3f2-410a-bd07-4743cfc65758',
+      companyId: 'e819fb11-d55f-4cbf-ad04-894d53cee722',
+      firstName: 'Dolapo',
+      lastName: 'Junior',
+      email: 'dolapo.junior@gmail.com',
+      password: hashHelper.hashPassword('password2019'),
+      gender: 'male',
+      dob: '2012-09-10',
+      status: 'active',
+      role: 'travel admin'
+    },
+    {
+      id: '54cef27e-a449-4f00-8a5c-d103be93ebb0',
+      companyId: 'e819fb11-d55f-4cbf-ad04-894d53cee722',
+      firstName: 'Bright',
+      lastName: 'John',
+      email: 'bright.john@gmail.com',
+      password: hashHelper.hashPassword('password2019'),
+      gender: 'male',
+      dob: '2012-09-10',
+      status: 'active',
+      role: 'manager'
+    },
+    {
+      id: 'f30f431e-0d60-47cd-ae8a-5864c5246d98',
+      companyId: 'e819fb11-d55f-4cbf-ad04-894d53cee722',
+      firstName: 'Mary',
+      lastName: 'Jane',
+      email: 'mary.jane@gmail.com',
+      password: hashHelper.hashPassword('password2019'),
+      gender: 'female',
+      dob: '2012-09-10',
+      status: 'active',
       role: 'travel admin'
     },
     {

--- a/src/database/seeders/20190829125544-create-locations.js
+++ b/src/database/seeders/20190829125544-create-locations.js
@@ -9,10 +9,52 @@ module.exports = {
     },
     {
       id: '3dd3b24a-7554-425e-a688-36afda195614',
+      companyId: 'a6e35eb9-8c59-4c7d-b8d4-ae724aa7fb61',
+      country: 'Nigeria',
+      city: 'Lagos'
+    },
+    {
+      id: 'bf308b41-56fe-47fb-ba50-36fb998a4d21',
+      companyId: 'a6e35eb9-8c59-4c7d-b8d4-ae724aa7fb61',
+      country: 'Nigeria',
+      city: 'Portharcourt'
+    },
+    {
+      id: '07eea927-ae7e-4f3d-a9f8-31651c0e66c6',
+      companyId: 'a6e35eb9-8c59-4c7d-b8d4-ae724aa7fb62',
+      country: 'Nigeria',
+      city: 'Abuja'
+    },
+    {
+      id: '48d67cc4-8056-4585-802b-905d940e27eb',
       companyId: 'a6e35eb9-8c59-4c7d-b8d4-ae724aa7fb62',
       country: 'Nigeria',
       city: 'Lagos'
-    }
+    },
+    {
+      id: 'bc6afe1c-70a2-4418-a88b-2a5e79eea008',
+      companyId: 'a6e35eb9-8c59-4c7d-b8d4-ae724aa7fb62',
+      country: 'Nigeria',
+      city: 'Portharcourt'
+    },
+    {
+      id: 'd6935e25-a979-4e0c-88f1-255bb44e22b9',
+      companyId: 'e819fb11-d55f-4cbf-ad04-894d53cee722',
+      country: 'Nigeria',
+      city: 'Abuja'
+    },
+    {
+      id: '33891516-0002-472d-9b2e-d9eca01f1db2',
+      companyId: 'e819fb11-d55f-4cbf-ad04-894d53cee722',
+      country: 'Nigeria',
+      city: 'Lagos'
+    },
+    {
+      id: 'a8ac5089-a87f-4c06-9556-c611835ab5ba',
+      companyId: 'e819fb11-d55f-4cbf-ad04-894d53cee722',
+      country: 'Nigeria',
+      city: 'Portharcourt'
+    },
   ]),
   down: queryInterface => queryInterface.bulkDelete('Locations', null, {})
 };

--- a/src/database/seeders/20190829125545-create-branches.js
+++ b/src/database/seeders/20190829125545-create-branches.js
@@ -29,7 +29,22 @@ module.exports = {
       id: '3dd3b34a-7554-455e-a688-36afda199159',
       name: 'Ibadan',
       locationId: '0190ae78-d184-4258-add5-0b2c6982efef'
-    }
+    },
+   {
+      id: '1404d644-fa2e-49a9-982f-eec3afeb5c0d',
+      name: 'Rumuokoro',
+      locationId: 'a8ac5089-a87f-4c06-9556-c611835ab5ba'
+    },
+    {
+      id: '7b717bff-9202-4c44-9848-80ec876b6fdc',
+      name: 'Ikeja',
+      locationId: '33891516-0002-472d-9b2e-d9eca01f1db2'
+    },
+    {
+      id: 'dbbe4992-4091-4914-a266-38ecdcf42083',
+      name: 'Gwagwalada',
+      locationId: 'd6935e25-a979-4e0c-88f1-255bb44e22b9'
+    },
   ]),
   down: (queryInterface) => queryInterface.bulkDelete('Branches', null, {})
 };

--- a/src/database/seeders/20190829125546-create-trips.js
+++ b/src/database/seeders/20190829125546-create-trips.js
@@ -1,3 +1,5 @@
+import timeframe from '../../../test/mockData/mockDate';
+import moment from 'moment';
 module.exports = {
   up: queryInterface => queryInterface.bulkInsert('Trips', [
     {
@@ -5,30 +7,33 @@ module.exports = {
       type: 'oneway',
       startBranchId: 'ffe35dbe-29ea-4759-8461-ed116f6739dd',
       userId: 'ffe25dbe-29ea-4759-8461-ed116f6739dd',
-      tripDate: '2019-02-17',
+      tripDate: timeframe.lastXDays(10).startDate,
       returnDate: '2019-02-23',
       reason: 'for holiday',
-      status: 'pending'
+      status: 'pending',
+      createdAt: timeframe.lastXDays(12).startDate
     },
     {
       id: 'ffe25dbe-29ea-4759-8468-ed116f6739df',
-      type: 'multiple',
+      type: 'oneway',
       startBranchId: 'ffe35dbe-29ea-4759-8461-ed116f6739dd',
       userId: '91542e6f-94bc-4e80-a667-586fb0752f23',
-      tripDate: '2019-02-17',
+      tripDate: timeframe.lastXDays(0).startDate,
       returnDate: '2019-02-23',
       reason: 'for holiday',
-      status: 'pending'
+      status: 'pending',
+      createdAt: timeframe.lastXDays(1).startDate
     },
     {
       id: 'ffe25dbe-29ea-4759-8462-ed116f6739df',
       type: 'return',
       startBranchId: 'ffe35dbe-29ea-4759-8461-ed116f6739dd',
       userId: '91542e6f-94bc-4e80-a667-586fb0752f23',
-      tripDate: '2019-08-30',
+      tripDate: timeframe.lastXDays(10).startDate,
       returnDate: '2019-09-23',
       reason: 'for work',
-      status: 'approved'
+      status: 'approved',
+      createdAt: timeframe.lastXDays(12).startDate
     },
     {
       id: 'ffe25dbe-29ea-4759-8462-ed116f6749df',
@@ -38,54 +43,91 @@ module.exports = {
       tripDate: '2019-09-01',
       returnDate: '2019-09-21',
       reason: 'to meet with clients',
-      status: 'rejected'
+      status: 'rejected',
+      createdAt: timeframe.lastXDays(12).startDate
     },
     {
       id: 'ffe25dbe-49ea-4759-8462-ed116f6749df',
       type: 'oneway',
       startBranchId: '3dd3b34a-7554-425e-a688-36afda199614',
       userId: '91542e6f-94bc-4e80-a667-586fb0752f25',
-      tripDate: '2019-10-01',
+      tripDate: timeframe.lastXDays(23).startDate,
       returnDate: null,
       reason: 'to meet with clients',
-      status: 'approved'
+      status: 'approved',
+      createdAt: timeframe.lastXDays(20).startDate
     },
     {
       id: '72a5c8f5-27eb-4623-b6f4-09f77cc871f3',
       type: 'oneway',
       startBranchId: '3dd3b34a-7554-425e-a688-36afda199614',
       userId: '91542e6f-94bc-4e80-a667-586fb0752f24',
-      tripDate: '2019-02-17',
+      tripDate: timeframe.lastXDays(14).startDate,
+      returnDate: null,
       reason: 'for holiday',
-      status: 'pending'
+      status: 'pending',
+      createdAt: timeframe.lastXDays(16).startDate
     },
     {
       id: 'ba3f6b93-f09e-49a4-bb28-c65555250bc1',
       type: 'return',
       startBranchId: '3dd3b34a-7554-425e-a688-36afda199614',
       userId: '91542e6f-94bc-4e80-a667-586fb0752f24',
-      tripDate: '2019-02-17',
-      returnDate: '2019-02-23',
+      tripDate: timeframe.lastXDays(7).startDate,
+      returnDate: '2019-12-23',
       reason: 'for holiday',
-      status: 'pending'
+      status: 'pending',
+      createdAt: timeframe.lastXDays(9).startDate
     },
     {
       id: 'db17ddb2-a6ba-49f5-9715-e0e81eb7720a',
       type: 'multiple',
       startBranchId: '3dd3b34a-7554-425e-a688-36afda199614',
       userId: '91542e6f-94bc-4e80-a667-586fb0752f24',
-      tripDate: '2019-02-17',
+      tripDate: timeframe.lastXDays(2).startDate,
       reason: 'for holiday',
-      status: 'pending'
+      status: 'pending',
+      createdAt: timeframe.lastXDays(3).startDate
     },
     {
       id: '4ae4fef9-8e5e-4d2a-879a-a0425cd3d5aa',
       type: 'oneway',
       startBranchId: '3dd3b34a-7554-425e-a688-36afda199614',
       userId: '91542e6f-94bc-4e80-a667-586fb0752f24',
-      tripDate: '2019-02-17',
+      tripDate: timeframe.lastXDays(2).startDate,
       reason: 'for holiday',
-      status: 'approved'
+      status: 'approved',
+      createdAt: timeframe.lastXDays(5).startDate
+    },
+    {
+      id: '1b91c1b4-3dbf-4412-ac59-252eb8d0b689',
+      type: 'oneway',
+      startBranchId: '3dd3b34a-7554-425e-a688-36afda199614',
+      userId: '91542e6f-94bc-4e80-a667-586fb0752f24',
+      tripDate: timeframe.nextXDay(27),
+      reason: 'for holiday',
+      status: 'approved',
+      createdAt: timeframe.lastXDays(2).startDate
+    },
+    {
+      id: '0467cec6-44cb-456a-8b08-d53f925f3239',
+      type: 'oneway',
+      startBranchId: '1404d644-fa2e-49a9-982f-eec3afeb5c0d',
+      userId: 'f30f431e-0d60-47cd-ae8a-5864c5246d98',
+      tripDate: timeframe.nextXDay(2),
+      reason: 'for holiday',
+      status: 'approved',
+      createdAt: timeframe.lastXDays(30).startDate
+    },
+    {
+      id: 'c1313777-d50d-4fa6-bd9d-807c25ceef41',
+      type: 'return',
+      startBranchId: '1404d644-fa2e-49a9-982f-eec3afeb5c0d',
+      userId: '54cef27e-a449-4f00-8a5c-d103be93ebb0',
+      tripDate: timeframe.nextXDay(0),
+      reason: 'for holiday',
+      status: 'approved',
+      createdAt: timeframe.lastXDays(14).startDate
     },
     {
       id: 'ff10015c-1624-4490-9b1f-1a2cf0ee4493',
@@ -95,7 +137,8 @@ module.exports = {
       tripDate: '2019-09-11',
       returnDate: null,
       reason: 'for meeting',
-      status: 'approved'
+      status: 'approved',
+      createdAt: timeframe.lastXDays(14).startDate
     },
     {
       id: 'ff10015c-1624-4490-9b1f-1a2cf0ee4492',
@@ -105,7 +148,8 @@ module.exports = {
       tripDate: '2019-09-15',
       returnDate: null,
       reason: 'meeting with company owner',
-      status: 'pending'
+      status: 'pending',
+      createdAt: timeframe.lastXDays(14).startDate
     }
   ]),
   down: queryInterface => queryInterface.bulkDelete('Trips', null, {})

--- a/src/database/seeders/20190829130100-create-accomodations.js
+++ b/src/database/seeders/20190829130100-create-accomodations.js
@@ -35,7 +35,28 @@ module.exports = {
       status: 'filled',
       imgurl: null,
       address: '31, Ocean drive, Lekki'
-    }
+    },
+    {
+      id: 'b4e9ba65-cb81-4b8a-8aec-1ffe24a9ed33',
+      name: 'Oriental',
+      branchId: '7b717bff-9202-4c44-9848-80ec876b6fdc',
+      capacity: 100,
+      status: 'filled'
+    },
+    {
+      id: 'b1a81334-fbf4-4160-83bf-e58f9063f7cf',
+      name: 'Crown Berry',
+      branchId: '1404d644-fa2e-49a9-982f-eec3afeb5c0d',
+      capacity: 100,
+      status: 'filled'
+    },
+    {
+      id: 'a16d39cd-3499-493a-8dd9-6141ed33df73',
+      name: 'Eko Hotel',
+      branchId: 'dbbe4992-4091-4914-a266-38ecdcf42083',
+      capacity: 100,
+      status: 'filled'
+    },
   ]),
   down: queryInterface => queryInterface.bulkDelete('Accomodations', null, {})
 };

--- a/src/database/seeders/20190829130101-create-stops.js
+++ b/src/database/seeders/20190829130101-create-stops.js
@@ -41,7 +41,25 @@ module.exports = {
       destinationBranchId: '1bf9f868-2a59-45ae-8f68-ad68095ca0ac',
       accomodationId: '3dd3b34a-7554-425e-c688-36afda199619',
       tripId: 'db17ddb2-a6ba-49f5-9715-e0e81eb7720a'
-    }
+    },
+    {
+      id: '0467cec6-44cb-456a-8b08-d53f925f3239',
+      destinationBranchId: '7b717bff-9202-4c44-9848-80ec876b6fdc',
+      accomodationId: '3dd3b34a-7554-425e-c688-36afda199619',
+      tripId: '0467cec6-44cb-456a-8b08-d53f925f3239'
+    },
+     {
+      id: '2d1ce275-f5c1-45c3-bed9-4cbd2ffa4769',
+      destinationBranchId: 'dbbe4992-4091-4914-a266-38ecdcf42083',
+      accomodationId: '3dd3b34a-7554-425e-c688-36afda199619',
+      tripId: 'db17ddb2-a6ba-49f5-9715-e0e81eb7720a'
+    },
+    {
+      id: '3789518f-93b0-4f97-9cdf-1ac5a32cf5c2',
+      destinationBranchId: '7b717bff-9202-4c44-9848-80ec876b6fdc',
+      accomodationId: 'b1a81334-fbf4-4160-83bf-e58f9063f7cf',
+      tripId: 'db17ddb2-a6ba-49f5-9715-e0e81eb7720a'
+    },
   ]),
   down: queryInterface => queryInterface.bulkDelete('Stops', null, {})
 };

--- a/src/routes/trip.routes.js
+++ b/src/routes/trip.routes.js
@@ -7,7 +7,8 @@ import verify from '../middlewares/AuthMiddlewares';
 import {
   tripRequestSchema,
   tripRequestStatusSchema,
-  editTripRequestSchema
+  editTripRequestSchema,
+  timeframeSchema
 } from '../validation/tripSchema';
 
 const tripRoutes = Router();
@@ -45,5 +46,11 @@ tripRoutes.patch(
 );
 
 tripRoutes.get('/mostvisited', Token.verifyToken, TripController.getMostVisitedBranch);
+tripRoutes.get(
+  '/timeframe',
+  Token.verifyToken,
+  validator(timeframeSchema),
+  TripController.countTripsByTimeframe
+);
 
 export default tripRoutes;

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -1,0 +1,19 @@
+const date = {
+    isToday: (value) => {
+        const today = new Date();
+        const date = new Date(value);
+        return today.getFullYear() === date.getFullYear() &&
+            today.getMonth() === date.getMonth() &&
+            today.getDate() === date.getDate();
+    },
+    format: (value) => {
+        return new Date(value).toLocaleDateString('en-GB', {
+            day: 'numeric',
+            month: 'short',
+            year: 'numeric',
+            time: 'numeric'
+        });
+    }
+};
+
+export default date;

--- a/src/validation/tripSchema.js
+++ b/src/validation/tripSchema.js
@@ -1,9 +1,10 @@
 import { body, check, param } from 'express-validator';
 import validateUUID from 'uuid-validate';
 import {
-  isValid, parseISO, isFuture
+  isValid, parseISO, isFuture, isDate
 } from 'date-fns';
 import models from '../database/models';
+import date from '../utils/date';
 
 const { Branch, Accomodation, Stop } = models;
 
@@ -215,6 +216,26 @@ const editTripRequestSchema = [
     }),
 ];
 
+const timeframeSchema = [
+  check('start')
+    .exists()
+    .withMessage('Start date is required')
+    .custom(value => isValid(parseISO(value)))
+    .withMessage('Invalid start date.')
+    .custom(value => date.isToday(value) || !isFuture(new Date(value)))
+    .withMessage('Date must be today or before today'),
+  check('end')
+    .exists()
+    .withMessage('end date is required')
+    .custom(value => isValid(parseISO(value)))
+    .withMessage('Invalid end date')
+    .custom(value => date.isToday(value) || isFuture(new Date(value)))
+    .withMessage('Date must be today or after'),
+];
+
 export {
-  tripRequestStatusSchema, tripRequestSchema, editTripRequestSchema
+  tripRequestStatusSchema,
+  tripRequestSchema,
+  editTripRequestSchema,
+  timeframeSchema
 };

--- a/swagger.json
+++ b/swagger.json
@@ -1230,7 +1230,102 @@
         }
       }
     },
-  "/user/accomodation/booking": {
+    "/trips/timeframe": {
+      "get": {
+        "tags": [
+          "Travel Requests"
+        ],
+        "summary": "Get stats of trip requests made in the last x timeframe",
+        "description": "Count trip requests",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "start",
+            "description": "Start date",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "end",
+            "description": "End date",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful update",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "code": {
+                      "type": "number",
+                      "example": 200
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Trip stat count results"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "tripCount": {
+                          "type": "number",
+                          "example": 5
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": false
+                    },
+                    "code": {
+                      "type": "number",
+                      "example": 400
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Validation Error!"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties":{
+                        "end":{
+                          "type": "string",
+                          "example": "end date is required"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/accomodation/booking": {
     "post": {
       "security": [
         {

--- a/test/editTripRequest.test.js
+++ b/test/editTripRequest.test.js
@@ -269,8 +269,8 @@ describe('Update trip request', () => {
           expect(trip.startBranchId).to.eql(multiTrip[0].from);
           expect(trip.reason).to.eql(multiTrip[0].reason);
           expect(new Date(trip.tripDate)).to.eql(new Date(departureDate));
-          expect(stop[1].destinationBranchId).to.eql(destinations[0].to);
-          expect(stop[1].accomodationId).to.eql(destinations[0].accomodation);
+          expect(stop[3].destinationBranchId).to.eql(destinations[0].to);
+          expect(stop[3].accomodationId).to.eql(destinations[0].accomodation);
           done();
         });
     });

--- a/test/mockData/mockAccomodation.js
+++ b/test/mockData/mockAccomodation.js
@@ -8,7 +8,7 @@ const accomodationWithWrongBranchId = {
 };
 const accomodationWrongCompany = {
   name: 'The new Accomodation center',
-  branchId: '3dd3b34a-7554-425e-a688-36afda199614',
+  branchId: '1404d644-fa2e-49a9-982f-eec3afeb5c0d',
   capacity: '20',
   address: 'This is the address of the center',
   imgurl: 'this is the image url'
@@ -52,7 +52,7 @@ const addRoom1 = {
 const roomInAnotherCompany = {
   name: 'Room 5',
   type: 'Executive Room',
-  accomodationId: '3dd3b34a-7554-425e-a688-36afda199619'
+  accomodationId: 'b4e9ba65-cb81-4b8a-8aec-1ffe24a9ed33'
 };
 const roomWithWrongAccId = {
   name: 'Room with Sauce',

--- a/test/mockData/mockAdmin.js
+++ b/test/mockData/mockAdmin.js
@@ -28,7 +28,7 @@ const branch2 = {
 
 const branch3 = {
   name: 'Jonny Hills Groups',
-  locationId: '3dd3b24a-7554-425e-a688-36afda195614'
+  locationId: '3dd3b24a-7554-425e-a688-36afda195714'
 };
 const admin = {
   location, inCompleteLocation, location2, branch, branch2, branch3, branch4

--- a/test/mockData/mockDate.js
+++ b/test/mockData/mockDate.js
@@ -1,0 +1,65 @@
+const timeFrameRange = {
+    getThisWeek: () => {
+        const today = new Date();
+        const day = today.getDate();
+        const nextDate = day + 1;
+        const endDate = new Date(today.setDate(nextDate)).toISOString();
+        const beginningOfTheWeek = day + (1 - today.getDay());
+        const prevDate = new Date(today.setDate(beginningOfTheWeek)).toISOString();
+        return { startDate: prevDate, endDate }
+    },
+    lastXDays: (days) => {
+        return { startDate: timeFrameRange.startXDays(days), endDate: timeFrameRange.endXDay() }
+    },
+    lastXmonths: (months) => {
+        var date = new Date();
+        const month = date.getMonth() - months;
+        date.setMonth(month)
+        const newDate = new Date(date).toISOString();
+        const endDate = new Date()
+        return { startDate: newDate, endDate: endDate.toISOString() }
+    },
+    endXDay: () => {
+        const today = new Date();
+        const day = today.getDate();
+        const nextDate = day;
+        const endDate = new Date(today.setDate(nextDate))
+        return endDate.toISOString();
+    },
+    nextXDay: (days) => {
+        const today = new Date();
+        const day = today.getDate();
+        const nextDate = day + days;
+        const endDate = new Date(today.setDate(nextDate));
+        return endDate.toISOString();
+    },
+    isTommorrow : (someDate) => {
+        const today = new Date()
+        return someDate.getDate() + 1 == today.getDate() + 1 &&
+            someDate.getMonth() == today.getMonth() &&
+            someDate.getFullYear() == today.getFullYear()
+    },
+    startXDays: (days) => {
+        const today = new Date();
+        const day = today.getDate();
+        const lastDate = day - days;
+        const startDate = new Date(today.setDate(lastDate));
+        return startDate.toISOString();
+    },
+    isIsoDate: (str) => {
+        let string = str
+        if (str.length > 10) string = str.toISOString().slice(0, 10)
+        if (!/\d{4}-\d{2}-\d{2}/.test(string)) return false;
+        var d = new Date(string);
+        return d.toISOString().slice(0, 10) === str;
+    },
+    isToday: (value) => {
+        const today = new Date();
+        const date = new Date(value);
+        return today.getFullYear() === date.getFullYear() &&
+            today.getMonth() === date.getMonth() &&
+            today.getDate() === date.getDate();
+    }
+};
+
+export default timeFrameRange;


### PR DESCRIPTION
#### What does this PR do?
Have a user get the counts of trips made within a period

#### Description of Task to be completed?

- [x] Write test
- [x] Validate timeframe(start and end date)
- [x] Modified seeders
- [x] Create a method that count trip request by time frame
- [x] Create a route handler
- [x] Write document with swagger

#### How should this be manually tested?

##### Unit test
1. Clone the project repository
2. Cd into the project repository
3. Run `git pull`
4. Run `git checkout  `ft-get-tripsStatByTimeframe-endpoint-167891607`
5. Run `npm install`
6. Create database `database_name`
7. Create .env file
8. Run npm test

##### Development test with Postman
 1. Run `npm run devstart`
 2. Launch postman
 3. Create a new get request with  `/api/v1/trips/timeframe?start=2019-xx-xx&end='2019-xx-xx` 
 4. Add authorization(token) in the request header.
 5. Hit send

#### What are the relevant pivotal tracker stories?
[#167891607](https://www.pivotaltracker.com/story/show/167891607)
#### Any background context you want to add?
Nil
#### Screenshots
![tripCount](https://user-images.githubusercontent.com/28379439/64837050-89a40b80-d5e4-11e9-9b6e-ee0b9ede7394.JPG)
