### PR TITLE
#167891594: User Marks Notifications as read

### DIFF
--- a/src/controllers/NotificationOpt.js
+++ b/src/controllers/NotificationOpt.js
@@ -1,5 +1,7 @@
 import Response from '../helpers/Response';
 import modifyUserNotificationOpt from '../helpers/modifyUserNotificationOpt';
+import removeUserNotification from '../helpers/removeUserNotification';
+import updateUserNotification from '../helpers/updateUserNotification';
 
 /** */
 class NotificationOpt {
@@ -56,6 +58,37 @@ class NotificationOpt {
     );
 
     return res.status(response.code).send(response);
+  }
+
+  /**
+   * @description Mark a users notification as read
+   * @param {Object} req request object
+   * @param {Object} res response object
+   * @returns {Object} Object
+   */
+  static async readAllNotifications(req, res) {
+    const { payload: { email } } = req.payload;
+    try {
+      const notifications = await removeUserNotification(email);
+      if (notifications.length < 1) {
+        return res.status(200).json(
+          new Response(true, 200, 'No notifications found')
+        );
+      }
+
+      notifications.forEach(async (notification) => {
+        const recipients = notification.recipients.filter((emailInArray) => emailInArray !== email);
+        await updateUserNotification(recipients, notification);
+      });
+
+      return res.status(200).json(
+        new Response(true, 200, 'Successfully mark all user notifications as read', notifications)
+      );
+    } catch (error) {
+      return res.status(500).json(
+        new Response(false, 500, error.message)
+      );
+    }
   }
 }
 

--- a/src/database/seeders/20190829125546-create-trips.js
+++ b/src/database/seeders/20190829125546-create-trips.js
@@ -106,7 +106,7 @@ module.exports = {
       returnDate: null,
       reason: 'meeting with company owner',
       status: 'pending'
-    }
+    },
   ]),
   down: queryInterface => queryInterface.bulkDelete('Trips', null, {})
 };

--- a/src/database/seeders/20190916133624-user-notifications.js
+++ b/src/database/seeders/20190916133624-user-notifications.js
@@ -1,0 +1,32 @@
+
+
+module.exports = {
+  up: (queryInterface) => queryInterface.bulkInsert('Notifications', [
+    {
+      id: '5df321d8-76f3-4d49-a025-071f9f45bca8',
+      tripId: 'c4a3f571-18da-4bd1-92e7-5c2906b86479',
+      recipients: '{banshee.admin@gmail.com,ogedengbe123@gmail.com}',
+      message: 'Babatunde Ogedengbe requested for a oneway trip',
+      createdAt: '2019-09-16 10:29:44.788+00',
+      updatedAt: '2019-09-16 10:29:44.788+00',
+    },
+    {
+      id: 'd1bd93e9-2892-4940-82f2-00c29ba20bec',
+      tripId: '8e101d1f-80e0-469b-abd7-2d9812d3d14b',
+      recipients: '{banshee.admin@gmail.com,ogedengbe123@gmail.com}',
+      message: 'Babatunde Ogedengbe requested for a return trip',
+      createdAt: '2019-09-16 10:29:44.788+00',
+      updatedAt: '2019-09-16 10:29:44.788+00',
+    },
+    {
+      id: '71542506-78bf-4e72-940a-85caca7af31a',
+      tripId: 'cd5dd483-46e1-426c-a5f2-45e586ee3bc1',
+      recipients: '{banshee.admin@gmail.com,ogedengbe123@gmail.com}',
+      message: 'Babatunde Ogedengbe requested for a oneway trip',
+      createdAt: '2019-09-16 10:29:44.788+00',
+      updatedAt: '2019-09-16 10:29:44.788+00',
+    }
+  ]),
+
+  down: queryInterface => queryInterface.bulkDelete('Notificaitons', null, {})
+};

--- a/src/helpers/removeUserNotification.js
+++ b/src/helpers/removeUserNotification.js
@@ -1,0 +1,22 @@
+import { Op } from 'sequelize';
+import db from '../database/models';
+
+const { Notification } = db;
+
+/**
+ * @description Get and remove a users notifications
+ * @param {String} email
+ * @returns {String} notifications
+ */
+
+const removeUsersNotification = email => Notification.findAll({
+  where: {
+    recipients: {
+      [Op.contains]: [email]
+    }
+  },
+  attributes: ['id', 'recipients'],
+  raw: true
+});
+
+export default removeUsersNotification;

--- a/src/helpers/updateUserNotification.js
+++ b/src/helpers/updateUserNotification.js
@@ -1,0 +1,11 @@
+import db from '../database/models';
+
+const { Notification } = db;
+
+const updateUserNotification = (recipients, notification) => Notification.update({
+  recipients
+}, {
+  where: { id: notification.id }
+});
+
+export default updateUserNotification;

--- a/src/routes/notificationOpt.routes.js
+++ b/src/routes/notificationOpt.routes.js
@@ -19,4 +19,10 @@ notificationOptRoute.patch(
   NotificationOpt.modifyInAppNotificationOption
 );
 
+notificationOptRoute.patch(
+  '/read',
+  TokenHelper.verifyAdminToken('travel admin', 'manager'),
+  NotificationOpt.readAllNotifications
+);
+
 export default notificationOptRoute;

--- a/test/mockData/mockAuth.js
+++ b/test/mockData/mockAuth.js
@@ -388,12 +388,24 @@ const nonManage = {
   email: 'ghaddafi@gmail.com',
   password: 'password2019',
   code: 'BAREFOOT'
-}
+};
 const managerLogin = {
   id: 'd885cb0d-8520-4ee1-bab7-d3097adadc32',
   companyId: 'a6e35eb9-8c59-4c7d-b8d4-ae724aa7fb61',
   email: 'managing.director@gmail.com',
   role: 'manager'
+};
+const travelAdmin2 = {
+  id: '91542e6f-94bc-4e81-a667-586fb0752f25',
+  email: 'banshee.admin@gmail.com',
+  companyId: 'a6e35eb9-8c59-4c7d-b8d4-ae724aa7fb62',
+  role: 'travel admin',
+};
+const travelAdmin3 = {
+  id: '91542e6f-94bc-4e80-a667-586fb0752f24',
+  companyId: 'a6e35eb9-8c59-4c7d-b8d4-ae724aa7fb62',
+  email: 'ogedengbe123@gmail.com',
+  role: 'travel admin',
 };
 
 const users = {
@@ -446,7 +458,9 @@ const users = {
   nonManager,
   nonManage,
   travelAdmin,
-  managerLogin
+  managerLogin,
+  travelAdmin2,
+  travelAdmin3
 };
 
 export default users;

--- a/test/notificationOpt.test.js
+++ b/test/notificationOpt.test.js
@@ -1,129 +1,176 @@
-import chai from "chai";
-import chaiHttp from "chai-http";
-import app from "../src/index";
-import users from "./mockData/mockAuth";
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import sinon from 'sinon';
+import app from '../src/index';
+import users from './mockData/mockAuth';
+import Token from '../src/helpers/Token';
+import db from '../src/database/models';
 
+const { Notification } = db;
 const { expect } = chai;
 chai.use(chaiHttp);
-const { adminAuth } = users;
+const { adminAuth, travelAdmin2 } = users;
 
-describe('NOTIFICATION OPTION TEST', () => {
-  it('should turn on email notification for admin user', done => {
-    const { token } = adminAuth;
-    chai
-      .request(app)
-      .patch(`/api/v1/notifications/email_opt`)
-      .set({ authorization: `${token}` })
-      .send({ emailOpt: true })
-      .end((err, res) => {
-        expect(res).to.have.status(200);
-        expect(res.body).to.be.an('object');
-        expect(res.body.data.email).to.equal('ogedengbe123@gmail.com');
-        expect(res.body.data.emailOpt).to.equal(true);
-        done();
-      });
-  });
-  it('should turn off email notification for admin user', done => {
-    const { token } = adminAuth;
-    chai
-      .request(app)
-      .patch('/api/v1/notifications/email_opt')
-      .set({ authorization: `${token}` })
-      .send({ emailOpt: false })
-      .end((err, res) => {
-        expect(res).to.have.status(200);
-        expect(res.body).to.be.an("object");
-        expect(res.body.data.email).to.equal('ogedengbe123@gmail.com');
-        expect(res.body.data.emailOpt).to.equal(false);
-        done();
-      });
-  });
+describe('NOTIFICATION OPTIONS', () => {
+  describe('NOTIFICATION OPTION TEST', () => {
+    it('should turn on email notification for admin user', (done) => {
+      const { token } = adminAuth;
+      chai
+        .request(app)
+        .patch('/api/v1/notifications/email_opt')
+        .set({ authorization: `${token}` })
+        .send({ emailOpt: true })
+        .end((err, res) => {
+          expect(res).to.have.status(200);
+          expect(res.body).to.be.an('object');
+          expect(res.body.data.email).to.equal('ogedengbe123@gmail.com');
+          expect(res.body.data.emailOpt).to.equal(true);
+          done();
+        });
+    });
+    it('should turn off email notification for admin user', (done) => {
+      const { token } = adminAuth;
+      chai
+        .request(app)
+        .patch('/api/v1/notifications/email_opt')
+        .set({ authorization: `${token}` })
+        .send({ emailOpt: false })
+        .end((err, res) => {
+          expect(res).to.have.status(200);
+          expect(res.body).to.be.an('object');
+          expect(res.body.data.email).to.equal('ogedengbe123@gmail.com');
+          expect(res.body.data.emailOpt).to.equal(false);
+          done();
+        });
+    });
 
-  it('should modify turn email notification without emailOpt', done => {
-    const { token } = adminAuth;
-    chai
-      .request(app)
-      .patch(`/api/v1/notifications/email_opt`)
-      .set({ authorization: `${token}` })
-      .send({})
-      .end((err, res) => {
-        expect(res).to.have.status(400);
-        expect(res.body.data.emailOpt).to.equal("Email option is required");
-        done();
-      });
-  });
-  it('should modify turn email notification without emailOpt', done => {
-    const { token } = adminAuth;
-    chai
-      .request(app)
-      .patch(`/api/v1/notifications/email_opt`)
-      .set({ authorization: `${token}` })
-      .send({emailOpt: 'trueggfgfsgf'})
-      .end((err, res) => {
-        expect(res).to.have.status(400);
-        expect(res.body.data.emailOpt).to.equal(
-          'Email option must be a boolean'
-        );
-        done();
-      });
-  });
-  it("should turn on in-app notification for admin user", done => {
-    const { token } = adminAuth;
-    chai
-      .request(app)
-      .patch(`/api/v1/notifications/in_app_opt`)
-      .set({ authorization: `${token}` })
-      .send({ inAppOpt: true })
-      .end((err, res) => {
-        expect(res).to.have.status(200);
-        expect(res.body).to.be.an("object");
-        expect(res.body.data.email).to.equal("ogedengbe123@gmail.com");
-        expect(res.body.data.inAppOpt).to.equal(true);
-        done();
-      });
-  });
-  it('should turn off in-app notification for admin user', done => {
-    const { token } = adminAuth;
-    chai
-      .request(app)
-      .patch(`/api/v1/notifications/in_app_opt`)
-      .set({ authorization: `${token}` })
-      .send({ inAppOpt: false })
-      .end((err, res) => {
-        expect(res).to.have.status(200);
-        expect(res.body).to.be.an("object");
-        expect(res.body.data.email).to.equal('ogedengbe123@gmail.com');
-        expect(res.body.data.inAppOpt).to.equal(false);
-        done();
-      });
-  });
+    it('should modify turn email notification without emailOpt', (done) => {
+      const { token } = adminAuth;
+      chai
+        .request(app)
+        .patch('/api/v1/notifications/email_opt')
+        .set({ authorization: `${token}` })
+        .send({})
+        .end((err, res) => {
+          expect(res).to.have.status(400);
+          expect(res.body.data.emailOpt).to.equal('Email option is required');
+          done();
+        });
+    });
+    it('should modify turn email notification without emailOpt', (done) => {
+      const { token } = adminAuth;
+      chai
+        .request(app)
+        .patch('/api/v1/notifications/email_opt')
+        .set({ authorization: `${token}` })
+        .send({ emailOpt: 'trueggfgfsgf' })
+        .end((err, res) => {
+          expect(res).to.have.status(400);
+          expect(res.body.data.emailOpt).to.equal(
+            'Email option must be a boolean'
+          );
+          done();
+        });
+    });
+    it('should turn on in-app notification for admin user', (done) => {
+      const { token } = adminAuth;
+      chai
+        .request(app)
+        .patch('/api/v1/notifications/in_app_opt')
+        .set({ authorization: `${token}` })
+        .send({ inAppOpt: true })
+        .end((err, res) => {
+          expect(res).to.have.status(200);
+          expect(res.body).to.be.an('object');
+          expect(res.body.data.email).to.equal('ogedengbe123@gmail.com');
+          expect(res.body.data.inAppOpt).to.equal(true);
+          done();
+        });
+    });
+    it('should turn off in-app notification for admin user', (done) => {
+      const { token } = adminAuth;
+      chai
+        .request(app)
+        .patch('/api/v1/notifications/in_app_opt')
+        .set({ authorization: `${token}` })
+        .send({ inAppOpt: false })
+        .end((err, res) => {
+          expect(res).to.have.status(200);
+          expect(res.body).to.be.an('object');
+          expect(res.body.data.email).to.equal('ogedengbe123@gmail.com');
+          expect(res.body.data.inAppOpt).to.equal(false);
+          done();
+        });
+    });
 
-  it("should not modify turn on notification without inAppOpt", done => {
-    const { token } = adminAuth;
-    chai
-      .request(app)
-      .patch(`/api/v1/notifications/in_app_opt`)
-      .set({ authorization: `${token}` })
-      .send({})
-      .end((err, res) => {
-        expect(res).to.have.status(400);
-        expect(res.body.data.inAppOpt).to.equal('In App option is required');
-        done();
-      });
+    it('should not modify turn on notification without inAppOpt', (done) => {
+      const { token } = adminAuth;
+      chai
+        .request(app)
+        .patch('/api/v1/notifications/in_app_opt')
+        .set({ authorization: `${token}` })
+        .send({})
+        .end((err, res) => {
+          expect(res).to.have.status(400);
+          expect(res.body.data.inAppOpt).to.equal('In App option is required');
+          done();
+        });
+    });
+    it('should not modify turn email notification with invalid inAppOpt', (done) => {
+      const { token } = adminAuth;
+      chai
+        .request(app)
+        .patch('/api/v1/notifications/in_app_opt')
+        .set({ authorization: `${token}` })
+        .send({ inAppOpt: 'trueggfgfsgf' })
+        .end((err, res) => {
+          expect(res).to.have.status(400);
+          expect(res.body.data.inAppOpt).to.equal(
+            'In App option must be a boolean'
+          );
+          done();
+        });
+    });
   });
-  it('should not modify turn email notification with invalid inAppOpt', done => {
-    const { token } = adminAuth;
-    chai
-      .request(app)
-      .patch('/api/v1/notifications/in_app_opt')
-      .set({ authorization: `${token}` })
-      .send({ inAppOpt: 'trueggfgfsgf' })
-      .end((err, res) => {
-        expect(res).to.have.status(400);
-        expect(res.body.data.inAppOpt).to.equal(
-          'In App option must be a boolean'
-        );
-        done();
-      });
+  describe('Mark all user notifications as read', () => {
+    const token = Token.generateToken(travelAdmin2);
+    const url = '/api/v1/notifications/read';
+    it('should mark all of a users\' notifications as read', (done) => {
+      chai
+        .request(app)
+        .patch(url)
+        .set('authorization', token)
+        .end((err, res) => {
+          expect(res.status).to.eq(200);
+          expect(res.body.message).to.eq('Successfully mark all user notifications as read');
+          expect(res.body.data).to.be.an('Array');
+          done();
+        });
+    });
+    it('should return empty array if no notifications are found', (done) => {
+      chai
+        .request(app)
+        .patch(url)
+        .set('authorization', token)
+        .end((err, res) => {
+          expect(res.status).to.eq(200);
+          expect(res.body.message).to.eq('No notifications found');
+          done();
+        });
+    });
+    it('should return error if there is server error', (done) => {
+      const stub = sinon.stub(Notification, 'findAll')
+        .rejects('There is an error processing your request');
+
+      chai
+        .request(app)
+        .patch(url)
+        .set('authorization', token)
+        .end((err, res) => {
+          expect(res.status).to.eq(500);
+          stub.restore();
+          done();
+        });
+    });
   });
 });


### PR DESCRIPTION
#### What does this PR do?

- Creates an endpoint for users to mark all in-app notifications as read

#### Description of Task to be completed?

- Check that is either `travel admin` or `manager` that is logged in
- Select a users notifications and update their status

#### How should this be manually tested?

- on postman, send a patch request with only token to `api/v1/notifications/read` to receive a response.

#### Any background context you want to provide?

-none

#### What are the relevant pivotal tracker stories?

[#167891594](https://www.pivotaltracker.com/story/show/167891594)

#### Screenshots (if appropriate)

![Screen Shot 2019-09-17 at 5 19 22 AM](https://user-images.githubusercontent.com/28492640/65011317-08fa4d80-d90b-11e9-90a3-e4a0e55d3df6.png)
